### PR TITLE
grafana: rewrite everything:

### DIFF
--- a/trusty/grafana/files/config.js
+++ b/trusty/grafana/files/config.js
@@ -20,13 +20,13 @@ define(['settings'], function(Settings) {
       datasources: {
         influxdb: {
           type: 'influxdb',
-          url: "http://DB_HOSTNAME:8086/db/INPUT_DATABASE",
+          url: "/influx/db/INPUT_DATABASE",
           username: 'DB_USER',
           password: 'DB_PASSWORD',
         },
         grafana: {
           type: 'influxdb',
-          url: "http://DB_HOSTNAME:8086/db/GRAFANA_DATABASE",
+          url: "/influx/db/GRAFANA_DATABASE",
           username: 'DB_USER',
           password: 'DB_PASSWORD',
           grafanaDB: true

--- a/trusty/grafana/files/nginx_notready
+++ b/trusty/grafana/files/nginx_notready
@@ -1,0 +1,11 @@
+server {
+        listen 80 default_server;
+        listen [::]:80 default_server ipv6only=on;
+        root @CHARM_DIR@/files/not_ready/;
+        index index.html index.htm;
+        server_name localhost;
+
+        location / {
+                try_files $uri $uri/ =404;
+        }
+}

--- a/trusty/grafana/files/nginx_ready
+++ b/trusty/grafana/files/nginx_ready
@@ -1,0 +1,15 @@
+server {
+        listen 80 default_server;
+        listen [::]:80 default_server ipv6only=on;
+        root /opt/grafana-1.9.1;
+        index index.html index.htm;
+        server_name localhost;
+
+        location /influx/ {
+                proxy_pass http://@DB_HOSTNAME@:8086/;
+        }
+
+        location / {
+                try_files $uri $uri/ =404;
+        }
+}

--- a/trusty/grafana/files/not_ready/index.html
+++ b/trusty/grafana/files/not_ready/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    You haven't related influxdb yet.
+  </body>
+</html>

--- a/trusty/grafana/hooks/install
+++ b/trusty/grafana/hooks/install
@@ -4,6 +4,6 @@ set -eux
 
 sudo apt-get -y install nginx-full
 tar -xvf $CHARM_DIR/files/grafana-1.9.1.tar.gz -C /opt
-sudo sed -i "s|/usr/share/nginx/html|/opt/grafana-1.9.1|g" /etc/nginx/sites-available/default
+sed -e "s|@CHARM_DIR@|$CHARM_DIR|g" $CHARM_DIR/files/nginx_notready | sudo tee /etc/nginx/sites-available/default > /dev/null
 
-cp $CHARM_DIR/files/config.js /opt/grafana-1.9.1/config.js
+sudo service nginx restart

--- a/trusty/grafana/hooks/query-relation-changed
+++ b/trusty/grafana/hooks/query-relation-changed
@@ -28,12 +28,11 @@ juju-log "Creating database: host: $HOST, user: $USER, pass: $PASSWORD"
 curl -s "http://$HOST:8086/db?u=$USER&p=$PASSWORD" -d "{\"name\": \"$GRAFANA_DATABASE\"}"
 curl -s "http://$HOST:8086/db?u=$USER&p=$PASSWORD" -d "{\"name\": \"$INPUT_DATABASE\"}"
 
-sed -i "s|DB_HOSTNAME|$HOST|g" $CHARM_DIR/files/config.js
-sed -i "s|DB_USER|$USER|g" $CHARM_DIR/files/config.js
-sed -i "s|DB_PASSWORD|$PASSWORD|g" $CHARM_DIR/files/config.js
-sed -i "s|INPUT_DATABASE|$INPUT_DATABASE|g" $CHARM_DIR/files/config.js
-sed -i "s|GRAFANA_DATABASE|$GRAFANA_DATABASE|g" $CHARM_DIR/files/config.js
+sed -e "s|DB_USER|$USER|g" \
+    -e "s|DB_PASSWORD|$PASSWORD|g" \
+    -e "s|INPUT_DATABASE|$INPUT_DATABASE|g" \
+    -e "s|GRAFANA_DATABASE|$GRAFANA_DATABASE|g" $CHARM_DIR/files/config.js > /opt/grafana-1.9.1/config.js
 
-cp $CHARM_DIR/files/config.js /opt/grafana-1.9.1/
+sed -e "s|@DB_HOSTNAME@|$HOST|g" $CHARM_DIR/files/nginx_ready | sudo tee /etc/nginx/sites-available/default > /dev/null
 
 sudo service nginx restart


### PR DESCRIPTION
- grafana always tells the browser to access influx at /influx on the grafana server
- /influx is proxied in the nginx config to the actual influx server
- make repeated execution of query-relation-changed hook work
- serve up a "not ready" page until influx is related.
